### PR TITLE
updating rds.DatabaseInstanceSourceProps to use credentials

### DIFF
--- a/lib/baseline-stacks/baseline-bindingdb.ts
+++ b/lib/baseline-stacks/baseline-bindingdb.ts
@@ -91,7 +91,7 @@ export class BindingDBBaseline extends cdk.Construct {
         
         const bindingDb = new rds.DatabaseInstance(this, 'bindingDb', {
             engine: rds.DatabaseInstanceEngine.oracleSe2({ version: rds.OracleEngineVersion.VER_19_0_0_0_2020_04_R1 }),
-            masterUsername: 'master',
+            credentials: rds.Credentials.fromPassword('master', this.DbSecret.secretValueFromJson('password')),
             licenseModel: rds.LicenseModel.BRING_YOUR_OWN_LICENSE,
             vpc: props.TargetVPC,
             vpcPlacement: appSubnetSelection, 
@@ -99,7 +99,6 @@ export class BindingDBBaseline extends cdk.Construct {
             optionGroup: bindingDbOptionGroup,
             instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL),
             instanceIdentifier: 'binding-db',
-            masterUserPassword: this.DbSecret.secretValueFromJson('password'),
             securityGroups: [this.DbAccessSg, DbSG],
             deletionProtection: false,
         });

--- a/lib/baseline-stacks/baseline-chembl.ts
+++ b/lib/baseline-stacks/baseline-chembl.ts
@@ -64,12 +64,11 @@ export class ChemblBaseline extends cdk.Construct {
         
         this.Chembl25DatabaseInstance = new rds.DatabaseInstance(this, 'chembl25', {
             engine: rds.DatabaseInstanceEngine.POSTGRES,
-            masterUsername: 'master',
+            credentials: rds.Credentials.fromPassword('master', this.DbSecret.secretValueFromJson('password')),
             vpc: props.TargetVPC,
             vpcPlacement: appSubnetSelection, 
             instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE2, ec2.InstanceSize.SMALL),
             instanceIdentifier: 'chembl-25',
-            masterUserPassword: chemblDBSecret.secretValueFromJson('password'),
             securityGroups: [chemblDbSG],
             deletionProtection: false
         });
@@ -77,12 +76,11 @@ export class ChemblBaseline extends cdk.Construct {
         
         this.Chembl27DatabaseInstance = new rds.DatabaseInstance(this, 'chembl27', {
             engine: rds.DatabaseInstanceEngine.POSTGRES,
-            masterUsername: 'master',
+            credentials: rds.Credentials.fromPassword('master', this.DbSecret.secretValueFromJson('password')),
             vpc: props.TargetVPC,
             vpcPlacement: appSubnetSelection, 
             instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE2, ec2.InstanceSize.SMALL),
             instanceIdentifier: 'chembl-27',
-            masterUserPassword: chemblDBSecret.secretValueFromJson('password'),
             securityGroups: [chemblDbSG],
             deletionProtection: false
         });


### PR DESCRIPTION
*Description of changes:*
Currently the Typescript is no longer compiling.

This is due to the fact the the rds.DatabaseInstanceProps interface now uses a credentials property rather than a username and password properties.

Have tested by doing the following:

1. Code now compiles
2. Deployed the environment and the SSM run command scripts are now able to use the dbSecrets to seed data in the RDS instances.

Am not able to make this PR to the master branch as the bindingdb stack is not in that branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
