### PR TITLE
updating Roda template synth script and fixing rds.DatabaseInstanceProps credentials prop

### DIFF
--- a/SynthRodaTemplates.sh
+++ b/SynthRodaTemplates.sh
@@ -1,16 +1,16 @@
-aws glue get-tables --database-name opentargets_1911_dl > RODA_templates/open_targets_1911_get_tables.json
-aws glue get-database --name opentargets_1911_dl > RODA_templates/open_targets_1911_get_database.json
+aws glue get-tables --database-name opentargets_1911_dl-awsroda > RODA_templates/open_targets_1911_get_tables.json
+aws glue get-database --name opentargets_1911_dl-awsroda > RODA_templates/open_targets_1911_get_database.json
 npm run build && cdk synth OpenTargetsRodaTemplate
 aws s3 cp cdk.out/OpenTargetsRodaTemplate.template.json s3://aws-roda-hcls-datalake/OpenTargetsRodaTemplate.json
 
 
-aws glue get-tables --database-name chembl_25_dl > RODA_templates/chembl_25_get_tables.json
-aws glue get-database --name chembl_25_dl > RODA_templates/chembl_25_get_database.json
+aws glue get-tables --database-name chembl_25_dl-awsroda > RODA_templates/chembl_25_get_tables.json
+aws glue get-database --name chembl_25_dl-awsroda > RODA_templates/chembl_25_get_database.json
 npm run build && cdk synth ChemblRodaTemplate
 aws s3 cp cdk.out/ChemblRodaTemplate.template.json s3://aws-roda-hcls-datalake/ChemblRodaTemplate.json
 
-aws glue get-tables --database-name binding_db_dl > RODA_templates/binding_db_get_tables.json
-aws glue get-database --name binding_db_dl > RODA_templates/binding_db_get_database.json
+aws glue get-tables --database-name binding_db_dl-awsroda > RODA_templates/binding_db_get_tables.json
+aws glue get-database --name binding_db_dl-awsroda > RODA_templates/binding_db_get_database.json
 npm run build && cdk synth BindingDbRodaTemplate
 aws s3 cp cdk.out/BindingDbRodaTemplate.template.json s3://aws-roda-hcls-datalake/BindingDbRodaTemplate.json
 

--- a/lib/baseline-stack.ts
+++ b/lib/baseline-stack.ts
@@ -85,12 +85,11 @@ export class BaselineStack extends cdk.Stack {
         
         const chemblDb = new rds.DatabaseInstance(this, 'chembl25', {
             engine: rds.DatabaseInstanceEngine.POSTGRES,
-            masterUsername: 'master',
+            credentials: rds.Credentials.fromPassword('master',chemblDBSecret.secretValueFromJson('password')),
             vpc: baselineVpc,
             vpcPlacement: appSubnetSelection, 
             instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE2, ec2.InstanceSize.SMALL),
             instanceIdentifier: 'chembl-25-00',
-            masterUserPassword: chemblDBSecret.secretValueFromJson('password'),
             securityGroups: [chemblDbSG],
             deletionProtection: false
         });
@@ -223,14 +222,13 @@ export class BaselineStack extends cdk.Stack {
         
         const bindingDb = new rds.DatabaseInstance(this, 'bindingDb', {
             engine: rds.DatabaseInstanceEngine.ORACLE_SE2,
-            masterUsername: 'master',
+            credentials: rds.Credentials.fromPassword('master',chemblDBSecret.secretValueFromJson('password')),
             licenseModel: rds.LicenseModel.BRING_YOUR_OWN_LICENSE,
             vpc: baselineVpc,
             vpcPlacement: appSubnetSelection, 
             optionGroup: bindingDbOptionGroup,
             instanceType: ec2.InstanceType.of(ec2.InstanceClass.BURSTABLE3, ec2.InstanceSize.SMALL),
             instanceIdentifier: 'binding-db',
-            masterUserPassword: bindingDBSecret.secretValueFromJson('password'),
             securityGroups: [bindingDbSg, bindingDbAccessSg],
             deletionProtection: false,
         });


### PR DESCRIPTION
## Commit 1 - updating Roda table and database names for template synth script
*Description of changes:*
The file SynthRodaTemplates.sh has incorrect naming of glue tables and database names that are created using the Cloudformation stacks that are suggested in comments at the bottom of the script.


## Commit 2 - updating rds.DatabaseInstanceSourceProps to use credentials object
Description of changes:
Currently, the Typescript is no longer compiling.

This is due to the fact the rds.DatabaseInstanceProps interface now uses a credentials property rather than a username and password properties.

Have tested by doing the following:

- Code now compiles
- Deployed the environment and the SSM run command scripts are now able to use the dbSecrets to seed data in the RDS instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


