### PR TITLE
Fixing KeyError in script for activating glue triggers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
- * @avrios/helios
+ * @avrios/data

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+ * @avrios/helios

--- a/lib/constructs/data-lake-enrollment.ts
+++ b/lib/constructs/data-lake-enrollment.ts
@@ -121,7 +121,7 @@ export class DataLakeEnrollment extends Construct {
     	const coarseLakeFormationPolicy = iam.PolicyStatement.fromJson(lakeFormationPolicy);
 
     	const policyParams = {
-    	  policyName: `${this.DataSetName}-coarseIamDataLakeAccessPolicy`,
+    	  managedPolicyName: `${this.DataSetName}-coarseIamDataLakeAccessPolicy`,
     	  statements: [
     	      s3PolicyStatement,
     	      gluePolicyStatement, 

--- a/scripts/lambda.activategluetigger.py
+++ b/scripts/lambda.activategluetigger.py
@@ -22,7 +22,7 @@ def main(event, context):
         
         if event['RequestType'] == 'Create':
             
-            triggerId = event['ResourceProperties']['TriggerId']
+            triggerId = event['ResourceProperties']['triggerId']
             response = glue.start_trigger(Name=triggerId);
             cfnresponse.send(event, context, cfnresponse.SUCCESS, response, triggerId);
     except Exception as e:


### PR DESCRIPTION
**COMMIT a24c1b8**

**Issue #, if available:**
n/a

**Description of changes:**
The lambda function was failing to activate the Glue triggers created due to a KeyError. Key should be `triggerId` (and not `TriggerId`) as specified in the properties of the three custom resources created in data-set-enrollment.ts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**COMMIT 6944b01**

**Issue #, if available:**
n/a

**Description of changes:**
The property name used for creating the managed policy was not correct (`policyName` instead of `managedPolicyName`, see [doc](https://docs.aws.amazon.com/cdk/api/v2//docs/aws-cdk-lib.aws_iam.ManagedPolicy.html#construct-props)). As a result, the stack could still be deployed but the name of the managed policy was not applied.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.