### PR TITLE
Mirror Open Target latest data release, to prevent releases aggregation

### DIFF
--- a/scripts/ssmdoc.import.opentargets.latest.json
+++ b/scripts/ssmdoc.import.opentargets.latest.json
@@ -27,7 +27,7 @@
               "echo 'Starting OpenTargets download...' >> /home/ssm-user/progressLogOpenTargetsLatest",
               "wget -r -nH --cut-dirs=5 -nc ftp://ftp.ebi.ac.uk//pub/databases/opentargets/platform/latest/output/etl/parquet/ -P opentargets/sourceExports/open-targets-data-releases/ >> /home/ssm-user/progressLogOpenTargetsLatest 2>/home/ssm-user/progressLogOpenTargetsLatest",
               "find opentargets/sourceExports/open-targets-data-releases/latest/ -type f -name '_SUCCESS' -delete",
-              "aws s3 sync opentargets/sourceExports/open-targets-data-releases/latest/ s3://{{openTargetsSourceFileTargetBucketLocation}}/opentargets/sourceExports/latest/"
+              "aws s3 sync opentargets/sourceExports/open-targets-data-releases/latest/ s3://{{openTargetsSourceFileTargetBucketLocation}}/opentargets/sourceExports/latest/ --delete"
             ]
          }
       }


### PR DESCRIPTION
Open Targets Community recently reported an overlap in disease terms / multiple entries for disease-gene associations in the data on S3, more details [here](https://community.opentargets.org/t/questions-about-the-22-06-dataset-overlap-in-disease-terms-multiple-entries-for-disease-gene-associations/698).

At Open Targets we have reviewed the data at our EBI FTP [repository](ftp.ebi.ac.uk:/pub/databases/opentargets/platform/latest/output/etl/parquet), compared to the data that is available on S3 at
```
s3://aws-roda-hcls-datalake/opentargets_latest/associationbydatatypeindirect/
```

We've also reviewed the process used to get Open Target latest release into S3, [here](https://github.com/aws-samples/data-lake-as-code/blob/roda/scripts/ssmdoc.import.opentargets.latest.json)

Taking into account that Open Targets ETL output uses non-overlapping file names and, although the S3 synchronization process cleans up a local folder for receiving Open Targets latest data, see [this](https://github.com/aws-samples/data-lake-as-code/blob/50f57f5b4b81773dfd0a67ab393fe10285899277/scripts/ssmdoc.import.opentargets.latest.json#L23-L24), before syncing the data to a bucket destination using
```
aws s3 sync
```

This process is performed as an aggregation, see [this](https://github.com/aws-samples/data-lake-as-code/blob/50f57f5b4b81773dfd0a67ab393fe10285899277/scripts/ssmdoc.import.opentargets.latest.json#L30)

We believe that may be the cause of this data discrepancy.

This PR addresses it by making sure that the data syncing is performed as a mirroring operation.

Kind Regards,
Manuel
Open Targets.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
